### PR TITLE
trouble at the mill initial commit

### DIFF
--- a/TroubleAtTheMill.sln
+++ b/TroubleAtTheMill.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TroubleAtTheMill", "TroubleAtTheMill\TroubleAtTheMill.csproj", "{1AF92916-703E-4734-9A93-9757E9F6A42F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1AF92916-703E-4734-9A93-9757E9F6A42F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1AF92916-703E-4734-9A93-9757E9F6A42F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1AF92916-703E-4734-9A93-9757E9F6A42F}.Debug|x86.ActiveCfg = Debug|x86
+		{1AF92916-703E-4734-9A93-9757E9F6A42F}.Debug|x86.Build.0 = Debug|x86
+		{1AF92916-703E-4734-9A93-9757E9F6A42F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1AF92916-703E-4734-9A93-9757E9F6A42F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1AF92916-703E-4734-9A93-9757E9F6A42F}.Release|x86.ActiveCfg = Release|x86
+		{1AF92916-703E-4734-9A93-9757E9F6A42F}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/TroubleAtTheMill/FatigueCalculator.cs
+++ b/TroubleAtTheMill/FatigueCalculator.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using Hearthstone_Deck_Tracker.Hearthstone;
+using Hearthstone_Deck_Tracker.Hearthstone.Entities;
+
+using CoreAPI = Hearthstone_Deck_Tracker.API.Core;
+
+namespace TroubleAtTheMill
+{
+    internal class FatigueCalculator
+    {
+        private FatigueDisplay fatigueDisplay;
+        private bool isLocal;
+
+        private Player player => isLocal ? CoreAPI.Game.Player : CoreAPI.Game.Opponent;
+        private Entity hero => player.Board.FirstOrDefault(x => x.IsHero);
+
+        public FatigueCalculator(FatigueDisplay fatigueDisplay, bool isLocal)
+        {
+            this.fatigueDisplay = fatigueDisplay;
+            this.isLocal = isLocal;
+        }
+
+        internal void GameStart()
+        {
+            fatigueDisplay.Show();
+            fatigueDisplay.UpdateText(isLocal ? "you" : "opponent");
+        }
+
+        internal void InMenu()
+        {
+            fatigueDisplay.Hide();
+        }
+
+        internal void Update()
+        {
+            updateFatigue();
+        }
+
+        private void updateFatigue()
+        {
+            if (this.player == null || this.hero == null)
+            {
+                return;
+            }
+
+            int playerHealth = this.hero.Health + this.hero.GetTag(HearthDb.Enums.GameTag.ARMOR);
+            if (playerHealth <= 0)
+            {
+                fatigueDisplay.UpdateText("ded");
+                fatigueDisplay.UpdateDetail(playerHealth.ToString());
+
+                return;
+            }
+
+            int playerCardsRemaining = this.player.DeckCount;
+            int playerFatigue = this.player.Fatigue + 1;
+
+            int drawsLeft = drawsUntilFatigue(playerCardsRemaining, playerFatigue, playerHealth);
+
+            fatigueDisplay.UpdateText(drawsLeft + " draws remaining");
+            fatigueDisplay.UpdateDetail(getDetailText(drawsLeft - playerCardsRemaining, playerFatigue, playerHealth));
+        }
+
+        private String getDetailText(int draws, int fatigue, int health)
+        {
+            int totalDamage = computeFatigueDamage(fatigue, draws);
+
+            StringBuilder detail = new StringBuilder();
+            detail.Append(health);
+            detail.Append(" - ");
+            for (int i = 0; i < draws; i++)
+            {
+                detail.Append(fatigue + i);
+                detail.Append((i == draws - 1) ? " = " : " - ");
+            }
+            detail.Append(health - totalDamage);
+
+            return detail.ToString();
+        }
+
+        private int computeFatigueDamage(int fatigueLevel, int numDraws)
+        {
+            // sum( f .. f+(d-1) )
+            // (f + (f+d-1)) + (f+1 + (f+d-2)) + [...]
+            //  ^1st ^last      ^2nd   ^2nd last
+            // ((f + (f+d-1)) / 2) * d
+            // ^ avg
+            //(2f + d - 1) / 2 * d
+
+            return (2 * fatigueLevel + numDraws - 1) * numDraws / 2;
+        }
+
+        private int drawsUntilFatigue(int cardsLeft, int fatigue, int health)
+        {
+            //(2f + d - 1)d / 2 = h
+            //(2f + d - 1)d = 2h
+            //2fd + d^2 - d = 2h
+            //d^2 + (2f-1)d - 2h = 0
+            //quadratic formula
+            //a=1, b = (2f-1), c = (-2h)
+            //
+            // d = ( -(2f-1) (+/-) sqrt( (2f-1)^2-4*1*(-2h) ) ) / 2*1
+            // d = ( -(2f-1) (+/-) sqrt( (2f-1)^2 + 8h ) ) / 2
+            // d = ( -(2f-1) (+/-) sqrt( (2f-1)(2f-1) + 8h ) ) /2
+            // d = ( -(2f-1) (+/-) sqrt (4f^2 - 4f + 1 + 8h) ) / 2
+
+            return cardsLeft + (int)Math.Ceiling((Math.Sqrt((4 * fatigue * fatigue) - 4 * fatigue + 1 + 8 * health) - 2 * fatigue + 1) / 2.0);
+        }
+    }
+}

--- a/TroubleAtTheMill/FatigueDisplay.xaml
+++ b/TroubleAtTheMill/FatigueDisplay.xaml
@@ -1,0 +1,14 @@
+﻿<UserControl x:Class="TroubleAtTheMill.FatigueDisplay"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:TroubleAtTheMill"
+             mc:Ignorable="d" 
+             d:DesignHeight="100" d:DesignWidth="300" Width="300" Height="100">
+    <Grid Background="#FF323232">
+        <TextBlock x:Name="textBlock" HorizontalAlignment="Center" Margin="0,-35,0,0" TextWrapping="Wrap" VerticalAlignment="Center" Width="300" FontSize="24" Foreground="White" TextAlignment="Center" FontWeight="Bold" Text="6 draws remaining"/>
+        <TextBlock x:Name="detailBlock" HorizontalAlignment="Center" Margin="0,0,0,-31" TextWrapping="Wrap" Text="38 - 3 - 4 - 5 - 6 - 7 - 8 - 9 - 10 = 162" VerticalAlignment="Center" Width="300" Foreground="White" TextAlignment="Center" FontFamily="Consolas"/>
+
+    </Grid>
+</UserControl>

--- a/TroubleAtTheMill/FatigueDisplay.xaml.cs
+++ b/TroubleAtTheMill/FatigueDisplay.xaml.cs
@@ -1,0 +1,59 @@
+﻿using Hearthstone_Deck_Tracker.API;
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace TroubleAtTheMill
+{
+    /// <summary>
+    /// Interaction logic for FatigueDisplay.xaml
+    /// </summary>
+    public partial class FatigueDisplay : UserControl
+    {
+        private bool isLocal;     
+        public FatigueDisplay(bool isLocal)
+        {
+            this.isLocal = isLocal;
+
+            InitializeComponent();
+            UpdatePosition();
+        }
+
+        public void UpdateText(String text)
+        {
+            this.textBlock.Text = text;
+            UpdatePosition();
+        }
+
+        public void UpdateDetail(String text)
+        {
+            this.detailBlock.Text = text;
+        }
+
+        private double ScreenRatio => (4.0 / 3.0) / (Core.OverlayCanvas.Width / Core.OverlayCanvas.Height);
+        public void UpdatePosition()
+        {
+            Canvas.SetTop(this, Core.OverlayCanvas.Height * 3 / 100);
+            var xPos = Hearthstone_Deck_Tracker.Helper.GetScaledXPos(8.0 / 100, (int)Core.OverlayCanvas.Width, ScreenRatio);
+
+            if (isLocal)
+            {                
+                Canvas.SetRight(this, xPos);
+            }
+            else
+            {
+                Canvas.SetLeft(this, xPos);
+            }
+        }
+
+        public void Show()
+        {
+            this.Visibility = Visibility.Visible;
+        }
+
+        public void Hide()
+        {
+            this.Visibility = Visibility.Hidden;
+        }
+    }
+}

--- a/TroubleAtTheMill/FatiguePlugin.cs
+++ b/TroubleAtTheMill/FatiguePlugin.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using Hearthstone_Deck_Tracker.Plugins;
+using Hearthstone_Deck_Tracker.API;
+using System.Windows;
+
+namespace TroubleAtTheMill
+{
+    public class FatiguePlugin : IPlugin
+    {
+        public string Name => "Trouble at the Mill";
+        public string Description
+            =>
+                "Displays the number of card draws until each player dies from fatigue.";
+
+        public string ButtonText => "DO NOT PUSH THIS BUTTON!";
+        public string Author => "realchriscasey";
+        public Version Version => new Version(0, 1, 2);
+        public System.Windows.Controls.MenuItem MenuItem => null;        
+
+        private List<UIElement> _displayElements;
+        private List<FatigueCalculator> _calculators;
+
+        void IPlugin.OnButtonPress()
+        {
+            /*NOP*/
+        }
+
+        void IPlugin.OnLoad()
+        {
+            _displayElements = new List<UIElement>();
+            _calculators = new List<FatigueCalculator>();
+
+            newCalculator(true);
+            newCalculator(false);
+        }
+
+        private void newCalculator(bool isLocal)
+        {
+            FatigueDisplay display = new FatigueDisplay(isLocal);
+            Core.OverlayCanvas.Children.Add(display);
+            _displayElements.Add(display);
+
+            FatigueCalculator fatigueCalculator = new FatigueCalculator(display, isLocal);
+            _calculators.Add(fatigueCalculator);
+
+            GameEvents.OnGameStart.Add(fatigueCalculator.GameStart);
+            GameEvents.OnInMenu.Add(fatigueCalculator.InMenu);            
+        }
+
+        void IPlugin.OnUnload()
+        {
+            foreach (UIElement element in _displayElements)
+            {
+                Core.OverlayCanvas.Children.Remove(element);
+            }
+            _displayElements.Clear();
+            _calculators.Clear(); //this probably memory leaks. not sure how to clean up the calculators from the notifications
+        }
+
+        //my apologies, I kept digging through and finding more places I needed to subscribe to an event.
+        //I wish there was an easy way to hook '# of cards in deck' and 'health' changes directly.
+        void IPlugin.OnUpdate()
+        {
+            foreach (FatigueCalculator calculator in _calculators)
+            {
+                calculator.Update();
+            }
+        }
+    }
+}

--- a/TroubleAtTheMill/Properties/AssemblyInfo.cs
+++ b/TroubleAtTheMill/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TroubleAtTheMill")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TroubleAtTheMill")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1af92916-703e-4734-9a93-9757e9f6a42f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TroubleAtTheMill/TroubleAtTheMill.csproj
+++ b/TroubleAtTheMill/TroubleAtTheMill.csproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1AF92916-703E-4734-9A93-9757E9F6A42F}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>hdt_fatigue</RootNamespace>
+    <AssemblyName>hdt_fatigue</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="HearthDb">
+      <HintPath>..\..\..\..\..\Desktop\Hearthstone Deck Tracker\HearthDb.dll</HintPath>
+    </Reference>
+    <Reference Include="Hearthstone Deck Tracker">
+      <HintPath>..\..\..\..\..\Desktop\Hearthstone Deck Tracker\Hearthstone Deck Tracker.exe</HintPath>
+    </Reference>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xaml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="FatigueCalculator.cs" />
+    <Compile Include="FatigueDisplay.xaml.cs">
+      <DependentUpon>FatigueDisplay.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="FatiguePlugin.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="FatigueDisplay.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
hearthstone fatigue damage tracker
Hearthstone Deck Tracker (HDT) plugin
- Displays the number of turns until each player dies
- Detail pane shows the math

Known issues:
- displays "6 draws remaining" debug message on startup
